### PR TITLE
Noremacskich/move docker steps into scripts

### DIFF
--- a/docs/BUILDING_DOCKER.md
+++ b/docs/BUILDING_DOCKER.md
@@ -6,21 +6,40 @@ To use Docker, you'll need either Docker Desktop or Docker Toolbox installed and
 
 You'll also need to prepare a local version of the project with a copied base ROM (see steps [2](../README.md#2-clone-the-repository) and [3](../README.md#3-prepare-a-base-rom) of the Linux instructions).
 
+**_Suggestion:_**  To avoid using sudo, look into "docker rootless" on google
+
 ## 2. Create the Docker image
 
 From inside your local project, run the following command:
 
 ```bash
+sh setup_docker.sh
+```
+
+Or if you are using a different environment
+
+```bash
 docker build . -t oot
 ```
+**_Note_**: you might need to use sudo to make these commands to work 
 
 ## 3. Start the container
 
-To start the container, you can mount your local filesystem into the Docker container and run an interactive bash session.
+From inside your local project, run the following command:
 
 ```bash
-docker run -it --rm --mount type=bind,source="$(pwd)",destination=/oot oot /bin/bash
+sh run_docker.sh
 ```
+
+Or if you are using a different environment
+
+```bash
+docker run -it --rm --mount type=bind,source="$(dirname $PWD)",destination=/oot oot /bin/bash
+```
+
+Where the mount, source portion is passing through the oot folder on your local filesystem into the Docker container and run an interactive bash session.
+
+**_Note_**: you might need to use sudo to make these commands to work
 
 ## 4. Setup and Build the ROM
 

--- a/docs/BUILDING_DOCKER.md
+++ b/docs/BUILDING_DOCKER.md
@@ -34,7 +34,7 @@ sh run_docker.sh
 Or if you are using a different environment
 
 ```bash
-docker run -it --rm --mount type=bind,source="$(dirname $PWD)",destination=/oot oot /bin/bash
+docker run -it --rm --mount type=bind,source="$(pwd)",destination=/oot oot /bin/bash
 ```
 
 Where the mount, source portion is passing through the oot folder on your local filesystem into the Docker container and run an interactive bash session.

--- a/run_docker.sh
+++ b/run_docker.sh
@@ -1,0 +1,1 @@
+docker run -it --rm --mount type=bind,source="$(pwd)",destination=/oot oot /bin/bash

--- a/setup_docker.sh
+++ b/setup_docker.sh
@@ -1,0 +1,1 @@
+docker build . -t oot


### PR DESCRIPTION
Moved the build and running steps from the docker readme into scripts that that can be run on command, without having to memorize the commands themselves

Also, updated the Docker steps with some tips, and have it directly reference the new scripts
